### PR TITLE
Replace rails dependency by all its dependencies except activestorage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: ruby
 os: linux
 rvm:
-  - 2.3.8
-  - jruby-9
-  - rbx-3
+  - 2.6
+  - 2.7
 gemfile:
-  - spec/gemfiles/rails_4_2.gemfile
   - spec/gemfiles/rails_5_0.gemfile
   - spec/gemfiles/rails_5_2.gemfile
 git:
@@ -21,15 +19,6 @@ jobs:
     gemfile: spec/gemfiles/rails_4_2.gemfile
 cache: bundler
 bundler_args: --path ../../vendor/bundle --without debug
-
-before_install:
-  # Rails 4.x requires bundler version < 2.0.
-  - >
-    if [[ $BUNDLE_GEMFILE == "${PWD}/spec/gemfiles/rails_4_2.gemfile" ]]; then
-      "find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete"
-      gem install bundler --version='~> 1.17'
-      bundler --version
-    fi
 
 script:
 - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.6
   - 2.7
 gemfile:
-  - spec/gemfiles/rails_5_0.gemfile
   - spec/gemfiles/rails_5_2.gemfile
 git:
   submodules: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rails'
-
 eval_gemfile './shared.gemfile'

--- a/rails_email_preview.gemspec
+++ b/rails_email_preview.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     s.metadata = { 'issue_tracker' => 'https://github.com/glebm/rails_email_preview' }
   end
 
-  # We need to remove acivestorage, which is a dependency of Rails
+  # We need to remove activestorage, which is a dependency of Rails
   # until https://github.com/rails/rails/issues/41750 is solved
   # beginning of Rails dependencies
   rails_version = ['~> 5.2', '< 6.0']

--- a/rails_email_preview.gemspec
+++ b/rails_email_preview.gemspec
@@ -17,7 +17,22 @@ Gem::Specification.new do |s|
     s.metadata = { 'issue_tracker' => 'https://github.com/glebm/rails_email_preview' }
   end
 
-  s.add_dependency 'rails', '>= 4.2'
+  # We need to remove acivestorage, which is a dependency of Rails
+  # until https://github.com/rails/rails/issues/41750 is solved
+  # beginning of Rails dependencies
+  rails_version = ['~> 5.2', '< 6.0']
+  s.add_dependency 'actionmailer', *rails_version
+  s.add_dependency 'actionpack', *rails_version
+  s.add_dependency 'actionview', *rails_version
+  s.add_dependency 'activejob', *rails_version
+  s.add_dependency 'activemodel', *rails_version
+  s.add_dependency 'activerecord', *rails_version
+  s.add_dependency 'activesupport', *rails_version
+  s.add_dependency 'railties', *rails_version
+  s.add_dependency 'bundler', '>= 1.3.0'
+  s.add_dependency 'sprockets-rails', '>= 2.0.0'
+  # end of Rails dependencies
+
   s.add_dependency 'sassc-rails', '>= 2.0.0'
   s.add_dependency 'turbolinks'
   s.add_dependency 'request_store'

--- a/spec/gemfiles/rails_5_0.gemfile
+++ b/spec/gemfiles/rails_5_0.gemfile
@@ -1,6 +1,0 @@
-source 'http://rubygems.org'
-
-gemspec path: '../..'
-
-gem 'rails', '~> 5.0.2'
-eval_gemfile '../../shared.gemfile'


### PR DESCRIPTION
related to https://github.com/rails/rails/issues/41750

It replaces rails dependency with all rails dependencies except `activestorage` which will use the yanked gem `mimemagic`.

It also limits rails version to `< 6` otherwise, it would be necessary some conditions in the gemspec file to add dependencies of Rails 6